### PR TITLE
Update GitHub URL in example READMEs

### DIFF
--- a/examples/client_auth/README.md
+++ b/examples/client_auth/README.md
@@ -8,7 +8,7 @@ A simple example app for client side authentication against the Platform API.
 npm install
 ```
 
-Make sure to add your clientId in the [config file](https://github.com/podio/platformJS/blob/master/examples/client_auth/public/javascript/config.js).
+Make sure to add your clientId in the [config file](https://github.com/podio/podio-js/blob/master/examples/client_auth/public/javascript/config.js).
 
 # Server
 

--- a/examples/password_auth/README.md
+++ b/examples/password_auth/README.md
@@ -8,7 +8,7 @@ A simple example app for password authentication against the Platform API.
 npm install
 ```
 
-Make sure to add your credentials to the [routes file](https://github.com/podio/platformJS/blob/master/examples/password_auth/routes/index.js#L6-L9).
+Make sure to add your credentials to the [routes file](https://github.com/podio/podio-js/blob/master/examples/password_auth/routes/index.js#L6-L9).
 
 # Server
 

--- a/examples/server_auth/README.md
+++ b/examples/server_auth/README.md
@@ -8,7 +8,7 @@ A simple example app for server-side authentication against the Platform API.
 npm install
 ```
 
-Make sure to add your clientId and clientSecret to the [routes file](https://github.com/podio/platformJS/blob/master/examples/server_auth/routes/index.js#L9-L10).
+Make sure to add your clientId and clientSecret to the [routes file](https://github.com/podio/podio-js/blob/master/examples/server_auth/routes/index.js#L9-L10).
 
 # Server
 


### PR DESCRIPTION
Updated broken example `README` GitHub urls.

*Note: added newline char as well*