### PR TITLE
install fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Podio Platform JavaScript SDK for NodeJS and the browser",
   "main": "lib/index",
   "scripts": {
+    "postinstall": "mkdir -p dist",
     "test": "./node_modules/jasmine-node/bin/jasmine-node test",
     "bundle": "browserify lib/podio-js.js -s PodioJS > dist/podio-js.js"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index",
   "scripts": {
     "test": "./node_modules/jasmine-node/bin/jasmine-node test",
-    "bundle": "browserify lib/podio-js.js -s podio-js > dist/podio-js.js"
+    "bundle": "browserify lib/podio-js.js -s PodioJS > dist/podio-js.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Exported global was being generated as 'podioJs' due to browserify camelCasing the hyphen. The client-auth example was broken due to expecting 'PodioJS'.

Also, the initial `npm run bundle` fails if the `dist` directory has not already been created. I used a postinstall hook here but mkdir -p won't work on Windows so maybe a placeholder file in the dir might be better.