### PR TITLE
Uses Promise for example `/user` request

### DIFF
--- a/examples/client_auth/public/javascript/authPopup.js
+++ b/examples/client_auth/public/javascript/authPopup.js
@@ -1,10 +1,10 @@
 /***
  * This code runs after a redirect with tokens in the hash fragment
  */
-(function(PlatformJS, SessionStore, PlatformConfig) {
+(function(PodioJS, SessionStore, PlatformConfig) {
 
   var clientId = PlatformConfig.clientId;
-  var platform = new PlatformJS({ authType: 'client', clientId: clientId }, { sessionStore: SessionStore });
+  var platform = new PodioJS({ authType: 'client', clientId: clientId }, { sessionStore: SessionStore });
 
   // will fetch the tokens from the hash fragment
   // and store them in the sessionStore

--- a/examples/client_auth/public/javascript/index.js
+++ b/examples/client_auth/public/javascript/index.js
@@ -73,9 +73,10 @@
     var elmBody = document.body;
 
     if (platform.isAuthenticated()) {
-      platform.request('get', '/user/status', null, function(responseData) {
-        elmBody.innerHTML = compiledUser({ profile: responseData.profile });
-      });
+      platform.request('get', '/user/status')
+        .then(function(responseData) {
+          elmBody.innerHTML = compiledUser({ profile: responseData.profile });
+        });
     } else {
       elmBody.innerHTML = compiledError();
     }

--- a/examples/client_auth/public/javascript/index.js
+++ b/examples/client_auth/public/javascript/index.js
@@ -1,7 +1,7 @@
-(function(PlatformJS, SessionStore, PlatformConfig, _) {
+(function(PodioJS, SessionStore, PlatformConfig, _) {
 
   var clientId = PlatformConfig.clientId;
-  var platform = new PlatformJS({ authType: 'client', clientId: clientId }, { sessionStore: SessionStore, onTokenWillRefresh: onTokenWillRefresh });
+  var platform = new PodioJS({ authType: 'client', clientId: clientId }, { sessionStore: SessionStore, onTokenWillRefresh: onTokenWillRefresh });
 
   var redirectURL = window.location.href + 'auth_popup';
   var compiledSuccess = _.template('<h1>Success!</h1><p>You are now authenticated to do API calls to Platform</p><a href="#" id="request-user">Make a /user request</a>');

--- a/examples/client_auth/views/auth_popup.ejs
+++ b/examples/client_auth/views/auth_popup.ejs
@@ -3,7 +3,7 @@
 <head>
   <title>Welcome to the demo</title>
   <link rel='stylesheet' href='/stylesheets/style.css' />
-  <script src="platform/PlatformJS.js"></script>
+  <script src="podio/podio-js.js"></script>
   <script src="javascript/sessionStore.js"></script>
   <script src="javascript/config.js"></script>
   <script src="javascript/authPopup.js"></script>


### PR DESCRIPTION
The callback isn't quite wired properly in platform.request. Using the promise interface makes the example run again.