### PR TITLE
Fixing routing error in server_auth example route index where an erro…

### DIFF
--- a/examples/server_auth/routes/index.js
+++ b/examples/server_auth/routes/index.js
@@ -37,8 +37,13 @@ router.get('/', function(req, res) {
 
     if (typeof authCode !== 'undefined') {
       podio.getAccessToken(authCode, redirectURL, function (err) {
-        // we are ready to make API calls
-        res.render('success');
+        if(err !== null) {
+          // we have catched an error
+          res.render('error', { description: 'Error:' + err.status + " / " + err.message });
+        } else {
+          // ready to make API calls
+          res.render('success');
+        }
       });
     } else if (typeof errorCode !== 'undefined') {
       // an error occured
@@ -51,13 +56,13 @@ router.get('/', function(req, res) {
 });
 
 router.get('/user', function(req, res) {
- 
+
   podio.isAuthenticated()
   .then(function() {
     return podio.request('get', '/user/status');
   })
   .then(function(responseData) {
-    res.render('user', { profile: responseData.profile });    
+    res.render('user', { profile: responseData.profile });
   })
   .catch(function(err) {
     res.send(401);


### PR DESCRIPTION
…r got rendered as success page

Hey guys, when I was experimenting with the examples I was always getting a success page even if there was an error 401 getting returned from the authentication with podio - very confusing because I couldn't understand why /users test route was giving back a 401. it turned out I just had an outdated secret in my config, but the message is not getting thru to the user. this fixes it

Ahoy!