### PR TITLE
Add checks in Transport for empty response object to prevent crashes

### DIFF
--- a/lib/transport.js
+++ b/lib/transport.js
@@ -72,7 +72,7 @@ module.exports = {
   _handleTransportError: function(options, response) {
     var request = options.requestParams;
 
-    if (!response) {
+    if (!response || !response.body) {
       return new PodioErrors.PodioError(null, null, request.url);
     }
 
@@ -108,7 +108,8 @@ module.exports = {
       options.resolve(res.body);
     } else {
       var isStatus401 = res && res.status === 401;
-      var isInvalidOrExpiredToken = (res.body.error === 'invalid_token' || res.body.error_description === 'expired_token');
+      var hasResBody = res && res.body;
+      var isInvalidOrExpiredToken = (hasResBody && (res.body.error === 'invalid_token' || res.body.error_description === 'expired_token'));
       var hasRefreshToken = this.authObject && this.authObject.refreshToken;
 
       if (isStatus401 && isInvalidOrExpiredToken && hasRefreshToken) {


### PR DESCRIPTION
Pretty simple checks for errors that probably weren't anticipated. (I suspect users were hitting this if the DB failed to respond to the API.)

Related: https://github.com/podio/podio-js/issues/51